### PR TITLE
Improved README and Installer Enhancements for Permanent PATH Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# autocord
-Installer and updater for Discord
+# Autocord
+Autocord is a tool to easily install and update Discord on your system.
+
+## Installation
+To install Autocord, run the following commands:
+```bash
+git clone https://github.com/Xdavius/autocord.git
+cd autocord
+./install.sh
+```
+This will clone the repository, navigate to the directory, and execute the installation script to set up Autocord.
+
+## Usage
+To install or update Discord, simply run:
+```bash
+autocord install
+```
+
+## Prerequisites
+Autocord requires the following tools to work correctly:
+
+- **jq**: A lightweight and flexible command-line JSON processor.
+- **curl**: For transferring data with URLs.
+- **tar**: To extract archived files.
+- **gzip**: For file compression and decompression.
+- **pv**: For monitoring the progress of data through a pipeline.
+
+Make sure these tools are installed on your system. For example, on Ubuntu/Debian-based systems, you can install them with:
+```bash
+sudo apt update
+sudo apt install jq curl tar gzip pv
+```

--- a/install.sh
+++ b/install.sh
@@ -5,10 +5,20 @@
 # - Set executable permissions for the script
 # - Reload shell configuration and execute installation
 
-# Create ~/.local/bin if it doesn't exist and add it to PATH
+# Create ~/.local/bin if it doesn't exist
 mkdir -p "${HOME}/.local/bin"
+
+# Add ~/.local/bin to PATH permanently if it's not already there
+if ! grep -q "$HOME/.local/bin" <<< "$PATH"; then
+    if [ -n "$BASH_VERSION" ]; then
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "${HOME}/.bashrc"
+    elif [ -n "$ZSH_VERSION" ]; then
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "${HOME}/.zshrc"
+    fi
+fi
+
+# Refresh PATH for the current session (if already open)
 export PATH="${HOME}/.local/bin:$PATH"
-export PATH="$(echo $PATH)" # Refresh PATH to avoid duplicates
 
 # Copy scripts and configuration files
 cp autocord.sh "${HOME}"/.local/bin/autocord
@@ -18,7 +28,11 @@ cp autocord-autostart.desktop "${HOME}"/.config/autostart/autocord-autostart.des
 chmod +x "${HOME}"/.local/bin/autocord
 
 # Reload shell configuration to apply changes
-. "${HOME}"/.bashrc
+if [ -n "$BASH_VERSION" ]; then
+    . "${HOME}/.bashrc"
+elif [ -n "$ZSH_VERSION" ]; then
+    . "${HOME}/.zshrc"
+fi
 
 # Run the Autocord installation process
 autocord install

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,24 @@
 #!/bin/bash
+# Prepare environment for Autocord
+# - Ensure ~/.local/bin exists and is in the PATH
+# - Copy necessary files to appropriate locations
+# - Set executable permissions for the script
+# - Reload shell configuration and execute installation
+
+# Create ~/.local/bin if it doesn't exist and add it to PATH
+mkdir -p "${HOME}/.local/bin"
+export PATH="${HOME}/.local/bin:$PATH"
+export PATH="$(echo $PATH)" # Refresh PATH to avoid duplicates
+
+# Copy scripts and configuration files
 cp autocord.sh "${HOME}"/.local/bin/autocord
 cp autocord-autostart.desktop "${HOME}"/.config/autostart/autocord-autostart.desktop
+
+# Make the main script executable
 chmod +x "${HOME}"/.local/bin/autocord
+
+# Reload shell configuration to apply changes
 . "${HOME}"/.bashrc
 
+# Run the Autocord installation process
 autocord install


### PR DESCRIPTION
- Improved the README to provide clearer installation and usage instructions.
- Modified the installer to permanently update the PATH by adding ~/.local/bin to the appropriate configuration file (~/.bashrc or ~/.zshrc).
- Fixed the installer to ensure the required directories are created if they don't exist.